### PR TITLE
Update and fix CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
       - uses: golangci/golangci-lint-action@v3
         with:
           args: --timeout 3m --verbose
+          skip-pkg-cache: true
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,24 @@ on:
     branches:
       - '**'
 jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.20'
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v4
+        with:
+          distribution: goreleaser
+          version: v1.17.2
+          args: release --snapshot --clean
+
   lint:
     runs-on: ubuntu-latest
+    needs: build
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    needs: lint
+    needs: build
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
@@ -47,7 +47,9 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
-    needs: test
+    needs:
+      - test
+      - lint
     permissions:
       contents: write
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           go-version: '1.20'
       - uses: golangci/golangci-lint-action@v3
         with:
-          args: --timeout 3m --verbose
+          args: --timeout 3m
           skip-pkg-cache: true
 
   test:


### PR DESCRIPTION
Adds a dedicated build step to CI runs and skips the package cache for golangci-lint as it outputs some errors